### PR TITLE
Feat: bump to rails 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,26 @@
 PATH
   remote: .
   specs:
-    bearer-rails (1.1.0)
-      activesupport (~> 5.2.3)
-      bearer (~> 1.0.0)
+    bearer-rails (2.0.0)
+      activesupport
+      bearer (~> 2.0.0)
       openssl (~> 2.1.2)
       rack (~> 2.0.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     backport (0.3.0)
-    bearer (1.0.1)
+    bearer (2.0.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -30,7 +31,7 @@ GEM
     ffi (1.10.0)
     hashdiff (0.3.8)
     htmlentities (4.3.4)
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     iniparse (1.4.4)
     ipaddr (1.2.2)
@@ -38,7 +39,7 @@ GEM
     kramdown (1.17.0)
     method_source (0.9.2)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.13.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     openssl (2.1.2)
@@ -106,6 +107,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff
     yard (0.9.20)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gem 'bearer-rails'
     Bearer::Configuration.setup do |config|
       config.api_key = "BEARER_SECRET_KEY" # copy and paste the `Secret Key` from https://app.bearer.sh/keys
       config.client_id = "BEARER_PUBLISHABLE_KEY" # copy and paste the `Publishable Key` from https://app.bearer.sh/keys
-      config.secret = "secret" # copy and paste the `Encryption Key` from https://app.bearer.sh/keys
+      config.encryption_key = "secret" # copy and paste the `Encryption Key` from https://app.bearer.sh/keys
     end
 ```
 

--- a/bearer-rails.gemspec
+++ b/bearer-rails.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 5.2.3"
-  spec.add_dependency "bearer", "~> 1.0.0"
+  spec.add_dependency "activesupport"
+  spec.add_dependency "bearer", "~> 2.0.0"
   spec.add_dependency "openssl", "~> 2.1.2"
   spec.add_dependency "rack", "~> 2.0.6"
 

--- a/lib/bearer-rails/version.rb
+++ b/lib/bearer-rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BearerRails
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
 end

--- a/lib/bearer-rails/webhook.rb
+++ b/lib/bearer-rails/webhook.rb
@@ -17,10 +17,6 @@ module BearerRails
       @body = body
     end
 
-    def bearer_invoke(function_name, params: {})
-      Bearer.call(buid, function_name, params: params)
-    end
-
     module ClassMethods
       def integration_handler(handler)
         BearerRails::Webhook.registry.push(class: self, handler: handler)

--- a/lib/bearer-rails/webhooks/bearer_invoke.rb
+++ b/lib/bearer-rails/webhooks/bearer_invoke.rb
@@ -26,7 +26,7 @@ module BearerRails
       end
 
       def check_sha(sha, body)
-        calculated_sha = OpenSSL::HMAC.hexdigest(digest, Bearer::Configuration.secret, body)
+        calculated_sha = OpenSSL::HMAC.hexdigest(digest, Bearer::Configuration.encryption_key, body)
         throw "Signature invalid" if sha != calculated_sha
       end
 

--- a/spec/bearer_rails/webhooks/bearer_invoke_spec.rb
+++ b/spec/bearer_rails/webhooks/bearer_invoke_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe BearerRails::BearerInvoke do
   before do
-    Bearer::Configuration.secret = "yZ23GR954QN4/QpvJ+OI78Iz/YrAeylM"
+    Bearer::Configuration.encryption_key = "yZ23GR954QN4/QpvJ+OI78Iz/YrAeylM"
   end
 
   let(:my_class) do


### PR DESCRIPTION
# What
Major release to use bearer 2.0.0, and support rails 6
# Why
bearer 1.2 is deprecated 

### Checklist
 - [ ] Rebased on master
 - [ ] Squashed commits to have tidy commit history
